### PR TITLE
add task to change manage.py mode after cloning the repo

### DIFF
--- a/tasks/setup-netbox.yml
+++ b/tasks/setup-netbox.yml
@@ -12,6 +12,11 @@
     dest: "{{ netbox_install_directory }}"
   register: netbox_downloaded
 
+- name: set management script permissions
+  file:
+    path: "{{ netbox_install_directory }}/netbox/manage.py"
+    mode: 0700
+
 - name: install virtualenv using pip
   pip:
     name: virtualenv


### PR DESCRIPTION
Since we're installing into a venv, we will need to remember that in order to run the script, we will need to use the venv's python to execute the script, e.g. `sudo /srv/netbox/bin/python /srv/netbox/netbox/manage.py createsuperuser`